### PR TITLE
Replace direct console logging with LogManager

### DIFF
--- a/src/main/services/selectionService.js
+++ b/src/main/services/selectionService.js
@@ -6,6 +6,10 @@
  * so this file simply re-exports the factory function.
  */
 const SelectionServiceImpl = require('./selection/SelectionService');
+const LogManager = require('../utils/LogManager');
+
+// Get a logger for this module
+const logger = LogManager.getLogger('selectionServiceCompat');
 
 // Get the singleton instance
 function getSelectionServiceInstance() {
@@ -20,11 +24,11 @@ function getSelectionServiceInstance() {
 async function getSelectionInParallel() {
   const selectionService = getSelectionServiceInstance();
   if (!selectionService) {
-    console.error('[SelectionService Compatibility] SelectionService not initialized');
+    logger.error('SelectionService not initialized');
     return '';
   }
-  
-  console.log('[SelectionService Compatibility] Getting selection in parallel');
+
+  logger.debug('Getting selection in parallel');
   return selectionService.getSelectionInParallel();
 }
 

--- a/src/main/utils/commandDetection.js
+++ b/src/main/utils/commandDetection.js
@@ -2,6 +2,10 @@
  * Advanced command detection utility for identifying AI commands in transcribed text
  * with confidence scoring to minimize false positives.
  */
+const LogManager = require('./LogManager');
+
+// Get a logger for this module
+const logger = LogManager.getLogger('commandDetection');
 
 /**
  * Determines if transcribed text contains an AI command with high confidence
@@ -144,13 +148,16 @@ function detectAICommand(transcribedText, actionVerbs, actionVerbsEnabled, aiTri
  * @param {string} transcribedText - The original transcribed text
  */
 function logCommandDetection(result, transcribedText) {
-  console.log('[Command Detection] Analysis:');
-  console.log(`  Text: "${transcribedText}"`);
-  console.log(`  Confidence: ${result.confidenceScore}`);
-  console.log(`  Is Command: ${result.isCommand}`);
-  console.log(`  Needs Confirmation: ${result.needsConfirmation}`);
-  console.log(`  Trigger Word Detected: ${result.isAITriggerWordDetected}`);
-  console.log(`  Detected Verb: ${result.detectedVerb || 'None'}`);
+  logger.debug('Command Detection Analysis', {
+    metadata: {
+      text: transcribedText,
+      confidence: result.confidenceScore,
+      isCommand: result.isCommand,
+      needsConfirmation: result.needsConfirmation,
+      triggerWordDetected: result.isAITriggerWordDetected,
+      detectedVerb: result.detectedVerb || 'None'
+    }
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- switch to LogManager-based logger in `configService`, `AudioUtils`, `windowManager` and other helpers
- replace direct `console.log`/`console.error` calls with logger methods

## Testing
- `npm test` *(fails: `jest` not found)*